### PR TITLE
Use a new link for compound extension warnings

### DIFF
--- a/lib/sass/selector/comma_sequence.rb
+++ b/lib/sass/selector/comma_sequence.rb
@@ -120,7 +120,7 @@ module Sass
             @@compound_extend_deprecation.warn(sseq.filename, sseq.line, <<WARNING)
 Extending a compound selector, #{sseq}, is deprecated and will not be supported in a future release.
 Consider "@extend #{sseq.members.join(', ')}" instead.
-See https://github.com/sass/sass/issues/1599 for details.
+See http://bit.ly/ExtendCompound for details.
 WARNING
           end
 

--- a/test/sass/extend_test.rb
+++ b/test/sass/extend_test.rb
@@ -539,7 +539,7 @@ SCSS
 DEPRECATION WARNING on line 2 of test_long_extendee_inline.scss:
 Extending a compound selector, .foo.bar, is deprecated and will not be supported in a future release.
 Consider "@extend .foo, .bar" instead.
-See https://github.com/sass/sass/issues/1599 for details.
+See http://bit.ly/ExtendCompound for details.
 WARNING
   end
 


### PR DESCRIPTION
See https://github.com/sass/sass-spec/pull/1246