### PR TITLE
Throw an error when passing a block to a mixin without @content

### DIFF
--- a/doc-src/SASS_CHANGELOG.md
+++ b/doc-src/SASS_CHANGELOG.md
@@ -7,6 +7,9 @@
 
 * Add a post-install message indicating that Ruby Sass is deprecated.
 
+* Properly emit an error when an empty block is passed to a mixin that doesn't
+  use `@content`.
+
 ## 3.5.6 (22 March 2018)
 
 * Allow `!` in custom property values.

--- a/lib/sass/tree/visitors/perform.rb
+++ b/lib/sass/tree/visitors/perform.rb
@@ -351,7 +351,7 @@ WARNING
       mixin = @environment.mixin(node.name)
       raise Sass::SyntaxError.new("Undefined mixin '#{node.name}'.") unless mixin
 
-      if node.children.any? && !mixin.has_content
+      if node.has_children && !mixin.has_content
         raise Sass::SyntaxError.new(%(Mixin "#{node.name}" does not accept a content block.))
       end
 


### PR DESCRIPTION
Closes #47
Closes sass/sass#2112
See sass/sass-spec#1268