### PR TITLE
Add source code link to gemspec

### DIFF
--- a/sass.gemspec
+++ b/sass.gemspec
@@ -21,11 +21,15 @@ SASS_GEMSPEC = Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_runtime_dependency 'sass-listen', '~> 4.0.0'
-  
+
   spec.add_development_dependency 'yard', '~> 0.8.7.6'
   spec.add_development_dependency 'redcarpet', '~> 3.3'
   spec.add_development_dependency 'nokogiri', '~> 1.6.0'
   spec.add_development_dependency 'minitest', '>= 5'
+
+  s.metadata = {
+    'source_code_uri' => 'https://github.com/sass/ruby-sass'
+  }
 
   readmes = Dir['*'].reject{ |x| x =~ /(^|[^.a-z])[a-z]+/ || x == "TODO" }
   spec.executables = ['sass', 'sass-convert', 'scss']


### PR DESCRIPTION
Currently, the source code link on [rubygems](https://rubygems.org/gems/sass/versions/3.5.7) links to the old `sass/sass` repo. This PR adds the URI to the gemspec, which will update Rubygems next time the gem is pushed. The URL can also be edited in the Rubygems UI.