### PR TITLE
Do not including test/** into gem.

### DIFF
--- a/sass.gemspec
+++ b/sass.gemspec
@@ -21,7 +21,7 @@ SASS_GEMSPEC = Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_runtime_dependency 'sass-listen', '~> 4.0.0'
-  
+
   spec.add_development_dependency 'yard', '~> 0.8.7.6'
   spec.add_development_dependency 'redcarpet', '~> 3.3'
   spec.add_development_dependency 'nokogiri', '~> 1.6.0'
@@ -29,11 +29,9 @@ SASS_GEMSPEC = Gem::Specification.new do |spec|
 
   readmes = Dir['*'].reject{ |x| x =~ /(^|[^.a-z])[a-z]+/ || x == "TODO" }
   spec.executables = ['sass', 'sass-convert', 'scss']
-  spec.files = Dir['rails/init.rb', 'lib/**/*', 'bin/*', 'test/**/*',
-    'extra/**/*', 'Rakefile', 'init.rb', '.yardopts'] + readmes
+  spec.files = Dir['rails/init.rb', '{lib,bin,extra}/**/*', 'init.rb', '.yardopts'] + readmes
   spec.homepage = 'http://sass-lang.com/'
   spec.has_rdoc = false
-  spec.test_files = Dir['test/**/*_test.rb']
   spec.license = "MIT"
 
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
Remove this to reduce gem size 1Mb.

<img width="451" alt="2018-10-16 18 11 02" src="https://user-images.githubusercontent.com/5518/47009354-df6efa00-d16e-11e8-9251-87480f0ceca1.png">

Same issue like: 

https://github.com/basecamp/marcel/pull/11
https://github.com/sparklemotion/nokogiri/pull/1804
https://github.com/plataformatec/devise/pull/4955

After:

```bash
$ gem build sass.gemspec
$ gem install sass-3.6.0.gem
$ ncdu /Users/jason/.rvm/gems/ruby-2.5.1/gems/sass-3.6.0
$ sass -v
Ruby Sass 3.6.0
$ irb

2.5.1 :001 > require "sass"
 => true 
2.5.1 :002 > Sass::VERSION
 => "3.6.0" 
```

<img width="383" alt="2018-10-17 16 39 35" src="https://user-images.githubusercontent.com/5518/47073692-6a152f00-d22b-11e8-85d2-7e05f031d075.png">