### PR TITLE
Eliminate "warning: assigned but unused variable - value"

### DIFF
--- a/lib/sass/script/functions.rb
+++ b/lib/sass/script/functions.rb
@@ -2908,9 +2908,9 @@ WARNING
 
     def percentage_or_unitless(number, max, name)
       if number.unitless?
-        value = number.value
+        number.value
       elsif number.is_unit?("%")
-        value = max * number.value / 100.0;
+        max * number.value / 100.0;
       else
         raise ArgumentError.new(
           "$#{name}: Expected #{number} to have no units or \"%\"");


### PR DESCRIPTION
This fixes following Ruby warning.

```
gems/sass-3.7.2/lib/sass/script/functions.rb:2911: warning: assigned but unused variable - value
```