### PR TITLE
Remove deprecated `has_rdoc=`

### DIFF
--- a/sass.gemspec
+++ b/sass.gemspec
@@ -33,7 +33,6 @@ SASS_GEMSPEC = Gem::Specification.new do |spec|
   spec.executables = ['sass', 'sass-convert', 'scss']
   spec.files = Dir['rails/init.rb', '{lib,bin,extra}/**/*', 'init.rb', '.yardopts'] + readmes
   spec.homepage = 'http://sass-lang.com/'
-  spec.has_rdoc = false
   spec.license = "MIT"
 
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
`Gem::Specification#has_rdoc=` is deprecated with no replacement.
Ref: https://travis-ci.org/sass/ruby-sass/jobs/452630055#L589-L596