### PR TITLE
Stop testing versions of Ruby before 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ install:
   - bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
   - bundle update sass-spec
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2
   - 2.3
   - 2.4
   - 2.5


### PR DESCRIPTION
These Ruby versions have been end-of-lifed, and they use a different
argument error format which breaks some specs.